### PR TITLE
Implement Ownership model

### DIFF
--- a/include/tmc/asio/aw_asio.hpp
+++ b/include/tmc/asio/aw_asio.hpp
@@ -18,7 +18,7 @@ protected:
   struct callback {
     aw_asio_base* me;
     template <typename... ResultArgs_> void operator()(ResultArgs_&&... Args) {
-      me->result.emplace(std::move(Args)...);
+      me->result.emplace(static_cast<ResultArgs_&&>(Args)...);
       if (me->continuation_executor == nullptr || me->continuation_executor == detail::this_thread::executor) {
         me->outer.resume();
       } else {
@@ -111,7 +111,7 @@ struct aw_asio_t {
     as_default_on(AsioIoType&& AsioIoObject) {
     return typename std::decay_t<AsioIoType>::template rebind_executor<
       executor_with_default<typename std::decay_t<AsioIoType>::executor_type>>::
-      other(std::forward<AsioIoType>(AsioIoObject));
+      other(static_cast<AsioIoType&&>(AsioIoObject));
   }
 };
 
@@ -138,8 +138,8 @@ struct async_result<tmc::aw_asio_t, void(ResultArgs...)> {
     std::tuple<InitArgs...> init_args;
     template <typename Init_, typename... InitArgs_>
     aw_asio(Init_&& Initiation, InitArgs_&&... Args)
-        : initiation(std::forward<Init_>(Initiation)),
-          init_args(std::forward<InitArgs_>(Args)...) {}
+        : initiation(static_cast<Init_&&>(Initiation)),
+          init_args(static_cast<InitArgs_&&>(Args)...) {}
 
     void initiate_await(
       tmc::aw_asio_base<std::decay_t<ResultArgs>...>::callback Callback
@@ -159,7 +159,7 @@ struct async_result<tmc::aw_asio_t, void(ResultArgs...)> {
   static aw_asio<std::decay_t<Init>, std::decay_t<InitArgs>...>
   initiate(Init&& Initiation, tmc::aw_asio_t, InitArgs&&... Args) {
     return aw_asio<std::decay_t<Init>, std::decay_t<InitArgs>...>(
-      std::forward<Init>(Initiation), std::forward<InitArgs>(Args)...
+      static_cast<Init&&>(Initiation), static_cast<InitArgs&&>(Args)...
     );
   }
 };

--- a/include/tmc/asio/aw_asio.hpp
+++ b/include/tmc/asio/aw_asio.hpp
@@ -28,7 +28,6 @@ protected:
   };
 
   virtual void initiate_await(callback Callback) = 0;
-  virtual ~aw_asio_base() = default;
 
   aw_asio_base()
       : continuation_executor(detail::this_thread::executor),
@@ -36,6 +35,7 @@ protected:
   aw_asio_base(aw_asio_base&& other) : result(std::move(other.result)) {}
 
 public:
+  virtual ~aw_asio_base() = default;
   bool await_ready() { return false; }
 
   void await_suspend(std::coroutine_handle<> Outer) noexcept {

--- a/include/tmc/asio/ex_asio.hpp
+++ b/include/tmc/asio/ex_asio.hpp
@@ -49,6 +49,11 @@ public:
       init_thread_locals(0);
       ioc.run();
     });
+
+    if (init_params != nullptr) {
+      delete init_params;
+      init_params = nullptr;
+    }
   }
   inline void teardown() {
     if (!is_initialized) {


### PR DESCRIPTION
Implement Ownership Model (move-only task) in sync with TMC (https://github.com/tzcnt/TooManyCooks/pull/7)

Implement set_thread_init_hook instead of setting thread_name in the executor