### PR TITLE
Implement `tmc::detail::awaitable_traits` for `tmc::aw_asio`

### DIFF
--- a/include/tmc/asio/aw_asio.hpp
+++ b/include/tmc/asio/aw_asio.hpp
@@ -22,7 +22,7 @@ template <typename... ResultArgs> class aw_asio_base {
 protected:
   std::optional<std::tuple<ResultArgs...>> result;
   std::coroutine_handle<> outer;
-  detail::type_erased_executor* continuation_executor;
+  tmc::detail::type_erased_executor* continuation_executor;
   size_t prio;
 
   struct callback {
@@ -30,11 +30,11 @@ protected:
     template <typename... ResultArgs_> void operator()(ResultArgs_&&... Args) {
       me->result.emplace(static_cast<ResultArgs_&&>(Args)...);
       auto exec = me->continuation_executor;
-      if (exec == nullptr || detail::this_thread::exec_is(exec)) {
+      if (exec == nullptr || tmc::detail::this_thread::exec_is(exec)) {
         me->outer.resume();
       } else {
         // post_checked is redundant with the prior check at the moment
-        detail::post_checked(exec, std::move(me->outer), me->prio);
+        tmc::detail::post_checked(exec, std::move(me->outer), me->prio);
       }
     }
   };
@@ -42,8 +42,8 @@ protected:
   virtual void initiate_await(callback Callback) = 0;
 
   aw_asio_base()
-      : continuation_executor(detail::this_thread::executor),
-        prio(detail::this_thread::this_task.prio) {}
+      : continuation_executor(tmc::detail::this_thread::executor),
+        prio(tmc::detail::this_thread::this_task.prio) {}
 
 public:
   virtual ~aw_asio_base() = default;

--- a/include/tmc/asio/aw_asio.hpp
+++ b/include/tmc/asio/aw_asio.hpp
@@ -18,7 +18,8 @@
 namespace tmc {
 
 /// Base class used to implement TMC awaitables for Asio operations.
-template <typename... ResultArgs> class aw_asio_base {
+template <typename... ResultArgs>
+class aw_asio_base : tmc::detail::AwaitTagNoGroupAsIs {
 protected:
   std::optional<std::tuple<ResultArgs...>> result;
   std::coroutine_handle<> outer;
@@ -55,7 +56,11 @@ public:
     initiate_await(callback{this});
   }
 
-  auto await_resume() noexcept { return *std::move(result); }
+  auto await_resume() noexcept {
+    // Move the result out of the optional
+    // (returns tuple<Result>, not optional<tuple<Result>>)
+    return *std::move(result);
+  }
 };
 
 struct aw_asio_t {

--- a/include/tmc/asio/aw_asio.hpp
+++ b/include/tmc/asio/aw_asio.hpp
@@ -56,6 +56,10 @@ protected:
   aw_asio_base() : prio(tmc::detail::this_thread::this_task.prio) {}
 
 public:
+  aw_asio_base(const aw_asio_base&) = default;
+  aw_asio_base(aw_asio_base&&) = default;
+  aw_asio_base& operator=(const aw_asio_base&) = default;
+  aw_asio_base& operator=(aw_asio_base&&) = default;
   virtual ~aw_asio_base() = default;
 };
 
@@ -77,8 +81,9 @@ template <IsAwAsio Awaitable> struct awaitable_traits<Awaitable> {
   // such as tmc::spawn_*()
   static constexpr awaitable_mode mode = ASYNC_INITIATE;
   static void async_initiate(
-    self_type&& awaitable, tmc::detail::type_erased_executor* Executor,
-    size_t Priority
+    self_type&& awaitable,
+    [[maybe_unused]] tmc::detail::type_erased_executor* Executor,
+    [[maybe_unused]] size_t Priority
   ) {
     awaitable.async_initiate();
   }

--- a/include/tmc/asio/aw_asio.hpp
+++ b/include/tmc/asio/aw_asio.hpp
@@ -96,7 +96,6 @@ template <IsAwAsio Awaitable> struct awaitable_traits<Awaitable> {
   }
 
   static void set_continuation(self_type& awaitable, void* Continuation) {
-    // TODO use awaitable_customizer
     awaitable.customizer.continuation = Continuation;
   }
 

--- a/include/tmc/asio/aw_asio.hpp
+++ b/include/tmc/asio/aw_asio.hpp
@@ -199,6 +199,7 @@ struct async_result<tmc::aw_asio_t, void(ResultArgs...)> {
   template <typename Init, typename... InitArgs>
   class aw_asio final
       : public tmc::aw_asio_base<std::decay_t<ResultArgs>...>,
+        // TODO - resume_on doesn't work right now
         public tmc::detail::resume_on_mixin<aw_asio<Init, InitArgs...>>,
         public tmc::detail::with_priority_mixin<aw_asio<Init, InitArgs...>>,
         tmc::detail::AwAsioTag {

--- a/include/tmc/asio/aw_asio.hpp
+++ b/include/tmc/asio/aw_asio.hpp
@@ -79,7 +79,7 @@ template <IsAwAsio Awaitable> struct awaitable_traits<Awaitable> {
 
   // Values controlling the behavior when wrapped by a utility function
   // such as tmc::spawn_*()
-  static constexpr awaitable_mode mode = ASYNC_INITIATE;
+  static constexpr configure_mode mode = ASYNC_INITIATE;
   static void async_initiate(
     self_type&& awaitable,
     [[maybe_unused]] tmc::detail::type_erased_executor* Executor,

--- a/include/tmc/asio/ex_asio.hpp
+++ b/include/tmc/asio/ex_asio.hpp
@@ -81,8 +81,8 @@ public:
     return &type_erased_this;
   }
   inline void init_thread_locals(size_t Slot) {
-    detail::this_thread::executor = &type_erased_this;
-    // detail::this_thread::this_task = {.prio = 0, .yield_priority =
+    tmc::detail::this_thread::executor = &type_erased_this;
+    // tmc::detail::this_thread::this_task = {.prio = 0, .yield_priority =
     // &yield_priority[slot]};
     if (init_params != nullptr && init_params->thread_init_hook != nullptr) {
       init_params->thread_init_hook(Slot);
@@ -90,8 +90,8 @@ public:
   }
 
   inline void clear_thread_locals() {
-    detail::this_thread::executor = nullptr;
-    // detail::this_thread::this_task = {};
+    tmc::detail::this_thread::executor = nullptr;
+    // tmc::detail::this_thread::this_task = {};
   }
   inline void graceful_stop() { ioc.stop(); }
 
@@ -126,7 +126,7 @@ private:
   friend class aw_ex_scope_enter<ex_asio>;
   inline std::coroutine_handle<>
   task_enter_context(std::coroutine_handle<> Outer, size_t Priority) {
-    if (detail::this_thread::exec_is(&type_erased_this)) {
+    if (tmc::detail::this_thread::exec_is(&type_erased_this)) {
       return Outer;
     } else {
       post(std::move(Outer), Priority);
@@ -140,6 +140,6 @@ inline ex_asio g_ex_asio;
 } // namespace detail
 
 /// Returns a reference to the global instance of `tmc::ex_asio`.
-constexpr ex_asio& asio_executor() { return detail::g_ex_asio; }
+constexpr ex_asio& asio_executor() { return tmc::detail::g_ex_asio; }
 
 } // namespace tmc


### PR DESCRIPTION
See https://github.com/tzcnt/TooManyCooks/pull/19

Implement a specialization of `tmc::detail::awaitable_traits` that allows `tmc::aw_asio` to be directly awaited by `tmc::task` and to be directly configured by `tmc::spawn*()` without needing an intermediate wrapper.

Use `tmc::detail::result_storage_t` so that we don't always need a `std::optional` when returning default-constructible types.