### PR TITLE
move work items in post()

### DIFF
--- a/include/tmc/asio/ex_asio.hpp
+++ b/include/tmc/asio/ex_asio.hpp
@@ -97,7 +97,7 @@ public:
 
   inline void post(work_item&& Item, [[maybe_unused]] size_t Priority) {
 #ifdef TMC_USE_BOOST_ASIO
-    boost::asio::post(ioc.get_executor(), item);
+    boost::asio::post(ioc.get_executor(), std::move(Item));
 #else
     asio::post(ioc.get_executor(), std::move(Item));
 #endif
@@ -107,7 +107,7 @@ public:
   void post_bulk(It Items, size_t Count, [[maybe_unused]] size_t Priority) {
     for (size_t i = 0; i < Count; ++i) {
 #ifdef TMC_USE_BOOST_ASIO
-      boost::asio::post(ioc.get_executor(), *Items);
+      boost::asio::post(ioc.get_executor(), std::move(*Items));
 #else
       asio::post(ioc.get_executor(), std::move(*Items));
 #endif

--- a/include/tmc/asio/ex_asio.hpp
+++ b/include/tmc/asio/ex_asio.hpp
@@ -99,7 +99,7 @@ public:
 #ifdef TMC_USE_BOOST_ASIO
     boost::asio::post(ioc.get_executor(), item);
 #else
-    asio::post(ioc.get_executor(), Item);
+    asio::post(ioc.get_executor(), std::move(Item));
 #endif
   }
 
@@ -109,7 +109,7 @@ public:
 #ifdef TMC_USE_BOOST_ASIO
       boost::asio::post(ioc.get_executor(), *Items);
 #else
-      asio::post(ioc.get_executor(), *Items);
+      asio::post(ioc.get_executor(), std::move(*Items));
 #endif
       ++Items;
     }


### PR DESCRIPTION
Always move work items into the executor in post(). This allows support for non-copyable types such as tmc::coro_functor and std::move_only_function.