### PR TITLE
implement thread_teardown_hook

### DIFF
--- a/include/tmc/asio/ex_asio.hpp
+++ b/include/tmc/asio/ex_asio.hpp
@@ -33,24 +33,24 @@ public:
 
   /// Hook will be invoked at the startup of each thread owned by this executor,
   /// and passed the ordinal index (0..thread_count()-1) of the thread.
-  inline ex_asio& set_thread_init_hook(void (*Hook)(size_t)) {
+  inline ex_asio& set_thread_init_hook(std::function<void(size_t)> Hook) {
     assert(!is_initialized);
     if (init_params == nullptr) {
       init_params = new InitParams;
     }
-    init_params->thread_init_hook = Hook;
+    init_params->thread_init_hook = std::move(Hook);
     return *this;
   }
 
   /// Hook will be invoked before destruction of each thread owned by this
   /// executor, and passed the ordinal index (0..thread_count()-1) of the
   /// thread.
-  inline ex_asio& set_thread_teardown_hook(void (*Hook)(size_t)) {
+  inline ex_asio& set_thread_teardown_hook(std::function<void(size_t)> Hook) {
     assert(!is_initialized);
     if (init_params == nullptr) {
       init_params = new InitParams;
     }
-    init_params->thread_teardown_hook = Hook;
+    init_params->thread_teardown_hook = std::move(Hook);
     return *this;
   }
 

--- a/include/tmc/asio/ex_asio.hpp
+++ b/include/tmc/asio/ex_asio.hpp
@@ -9,13 +9,14 @@
 #include <asio/any_io_executor.hpp>
 #include <asio/io_context.hpp>
 #include <asio/post.hpp>
+#include <functional>
 #include <thread>
 
 namespace tmc {
 class ex_asio {
   struct InitParams {
-    void (*thread_init_hook)(size_t) = nullptr;
-    void (*thread_teardown_hook)(size_t) = nullptr;
+    std::function<void(size_t)> thread_init_hook = nullptr;
+    std::function<void(size_t)> thread_teardown_hook = nullptr;
   };
   InitParams* init_params = nullptr;
 
@@ -65,12 +66,8 @@ public:
     ioc.get_executor().on_work_started();
 
     InitParams params;
-    if (init_params != nullptr && init_params->thread_init_hook != nullptr) {
-      params.thread_init_hook = init_params->thread_init_hook;
-    }
-    if (init_params != nullptr &&
-        init_params->thread_teardown_hook != nullptr) {
-      params.thread_teardown_hook = init_params->thread_teardown_hook;
+    if (init_params != nullptr) {
+      params = *init_params;
     }
 
     ioc_thread = std::jthread([this, params]() {


### PR DESCRIPTION
set_thread_teardown_hook() allows adding a function that will be called before each executor thread is destroyed. This function will be passed the index of the thread. It is similar to set_thread_init_hook() which is called when the thread is created.

Update both the init_hook and teardown_hook functions to use std::function instead of a function pointer - to support stateful hooks such as lambdas.