### PR TITLE
post() supports optional parameters Priority and ThreadHint

### DIFF
--- a/include/tmc/asio/ex_asio.hpp
+++ b/include/tmc/asio/ex_asio.hpp
@@ -173,16 +173,15 @@ private:
 namespace detail {
 template <> struct executor_traits<tmc::ex_asio> {
   static inline void post(
-    tmc::ex_asio& ex, tmc::work_item&& Item, size_t Priority = 0,
-    size_t ThreadHint = TMC_ALL_ONES
+    tmc::ex_asio& ex, tmc::work_item&& Item, size_t Priority, size_t ThreadHint
   ) {
     ex.post(std::move(Item), Priority, ThreadHint);
   }
 
   template <typename It>
   static inline void post_bulk(
-    tmc::ex_asio& ex, It&& Items, size_t Count, size_t Priority = 0,
-    size_t ThreadHint = TMC_ALL_ONES
+    tmc::ex_asio& ex, It&& Items, size_t Count, size_t Priority,
+    size_t ThreadHint
   ) {
     ex.post_bulk(std::forward<It>(Items), Count, Priority, ThreadHint);
   }

--- a/include/tmc/asio/ex_asio.hpp
+++ b/include/tmc/asio/ex_asio.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 #include "tmc/aw_resume_on.hpp"
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/thread_locals.hpp"
 #include <asio/any_io_executor.hpp>
 #include <asio/io_context.hpp>
@@ -125,7 +126,7 @@ public:
 
   inline void post(
     work_item&& Item, [[maybe_unused]] size_t Priority = 0,
-    [[maybe_unused]] size_t ThreadHint = TMC_ALL_ONES
+    [[maybe_unused]] size_t ThreadHint = NO_HINT
   ) {
 #ifdef TMC_USE_BOOST_ASIO
     boost::asio::post(ioc.get_executor(), std::move(Item));
@@ -137,7 +138,7 @@ public:
   template <typename It>
   void post_bulk(
     It Items, size_t Count, [[maybe_unused]] size_t Priority = 0,
-    [[maybe_unused]] size_t ThreadHint = TMC_ALL_ONES
+    [[maybe_unused]] size_t ThreadHint = NO_HINT
   ) {
     for (size_t i = 0; i < Count; ++i) {
 #ifdef TMC_USE_BOOST_ASIO

--- a/include/tmc/asio/ex_asio.hpp
+++ b/include/tmc/asio/ex_asio.hpp
@@ -123,8 +123,10 @@ public:
   }
   inline void graceful_stop() { ioc.stop(); }
 
-  inline void
-  post(work_item&& Item, [[maybe_unused]] size_t Priority, size_t ThreadHint) {
+  inline void post(
+    work_item&& Item, [[maybe_unused]] size_t Priority = 0,
+    [[maybe_unused]] size_t ThreadHint = TMC_ALL_ONES
+  ) {
 #ifdef TMC_USE_BOOST_ASIO
     boost::asio::post(ioc.get_executor(), std::move(Item));
 #else
@@ -134,7 +136,8 @@ public:
 
   template <typename It>
   void post_bulk(
-    It Items, size_t Count, [[maybe_unused]] size_t Priority, size_t ThreadHint
+    It Items, size_t Count, [[maybe_unused]] size_t Priority = 0,
+    [[maybe_unused]] size_t ThreadHint = TMC_ALL_ONES
   ) {
     for (size_t i = 0; i < Count; ++i) {
 #ifdef TMC_USE_BOOST_ASIO
@@ -170,15 +173,16 @@ private:
 namespace detail {
 template <> struct executor_traits<tmc::ex_asio> {
   static inline void post(
-    tmc::ex_asio& ex, tmc::work_item&& Item, size_t Priority, size_t ThreadHint
+    tmc::ex_asio& ex, tmc::work_item&& Item, size_t Priority = 0,
+    size_t ThreadHint = TMC_ALL_ONES
   ) {
     ex.post(std::move(Item), Priority, ThreadHint);
   }
 
   template <typename It>
   static inline void post_bulk(
-    tmc::ex_asio& ex, It&& Items, size_t Count, size_t Priority,
-    size_t ThreadHint
+    tmc::ex_asio& ex, It&& Items, size_t Count, size_t Priority = 0,
+    size_t ThreadHint = TMC_ALL_ONES
   ) {
     ex.post_bulk(std::forward<It>(Items), Count, Priority, ThreadHint);
   }

--- a/include/tmc/asio/ex_asio.hpp
+++ b/include/tmc/asio/ex_asio.hpp
@@ -10,6 +10,7 @@
 #include <asio/any_io_executor.hpp>
 #include <asio/io_context.hpp>
 #include <asio/post.hpp>
+#include <cassert>
 #include <functional>
 #include <thread>
 

--- a/include/tmc/asio/ex_asio.hpp
+++ b/include/tmc/asio/ex_asio.hpp
@@ -164,7 +164,7 @@ private:
     if (tmc::detail::this_thread::exec_is(&type_erased_this)) {
       return Outer;
     } else {
-      post(std::move(Outer), Priority, TMC_ALL_ONES);
+      post(std::move(Outer), Priority);
       return std::noop_coroutine();
     }
   }


### PR DESCRIPTION
In lockstep with https://github.com/tzcnt/TooManyCooks/pull/38

- post() / post_bulk() parameter `Priority` is now optional, with default value 0 (highest priority)
- new `ThreadHint` optional parameter is available, with default value NO_HINT

For ex_asio, both of these parameters are ignored, so this is just a matter of API compatibility.