### PR TITLE
Rename `tmc::detail::type_erased_executor` to `tmc::ex_any`

### DIFF
--- a/include/tmc/asio/aw_asio.hpp
+++ b/include/tmc/asio/aw_asio.hpp
@@ -82,8 +82,7 @@ template <IsAwAsio Awaitable> struct awaitable_traits<Awaitable> {
   // such as tmc::spawn_*()
   static constexpr configure_mode mode = ASYNC_INITIATE;
   static void async_initiate(
-    self_type&& awaitable,
-    [[maybe_unused]] tmc::detail::type_erased_executor* Executor,
+    self_type&& awaitable, [[maybe_unused]] tmc::detail::ex_any* Executor,
     [[maybe_unused]] size_t Priority
   ) {
     awaitable.async_initiate();
@@ -237,8 +236,7 @@ struct async_result<tmc::aw_asio_t, void(ResultArgs...)> {
 
   public:
     /// The wrapped task will run on the provided executor.
-    [[nodiscard]] inline aw_asio&
-    resume_on(tmc::detail::type_erased_executor* Executor) & {
+    [[nodiscard]] inline aw_asio& resume_on(tmc::detail::ex_any* Executor) & {
       this->customizer.continuation_executor = Executor;
       return *this;
     }
@@ -258,8 +256,7 @@ struct async_result<tmc::aw_asio_t, void(ResultArgs...)> {
     }
 
     /// The wrapped task will run on the provided executor.
-    [[nodiscard]] inline aw_asio&&
-    resume_on(tmc::detail::type_erased_executor* Executor) && {
+    [[nodiscard]] inline aw_asio&& resume_on(tmc::detail::ex_any* Executor) && {
       this->customizer.continuation_executor = Executor;
       return std::move(*this);
     }

--- a/include/tmc/asio/aw_asio.hpp
+++ b/include/tmc/asio/aw_asio.hpp
@@ -82,7 +82,7 @@ template <IsAwAsio Awaitable> struct awaitable_traits<Awaitable> {
   // such as tmc::spawn_*()
   static constexpr configure_mode mode = ASYNC_INITIATE;
   static void async_initiate(
-    self_type&& awaitable, [[maybe_unused]] tmc::detail::ex_any* Executor,
+    self_type&& awaitable, [[maybe_unused]] tmc::ex_any* Executor,
     [[maybe_unused]] size_t Priority
   ) {
     awaitable.async_initiate();
@@ -236,7 +236,7 @@ struct async_result<tmc::aw_asio_t, void(ResultArgs...)> {
 
   public:
     /// The wrapped task will run on the provided executor.
-    [[nodiscard]] inline aw_asio& resume_on(tmc::detail::ex_any* Executor) & {
+    [[nodiscard]] inline aw_asio& resume_on(tmc::ex_any* Executor) & {
       this->customizer.continuation_executor = Executor;
       return *this;
     }
@@ -256,7 +256,7 @@ struct async_result<tmc::aw_asio_t, void(ResultArgs...)> {
     }
 
     /// The wrapped task will run on the provided executor.
-    [[nodiscard]] inline aw_asio&& resume_on(tmc::detail::ex_any* Executor) && {
+    [[nodiscard]] inline aw_asio&& resume_on(tmc::ex_any* Executor) && {
       this->customizer.continuation_executor = Executor;
       return std::move(*this);
     }

--- a/include/tmc/asio/ex_asio.hpp
+++ b/include/tmc/asio/ex_asio.hpp
@@ -30,7 +30,7 @@ public:
 #endif
   ioc_t ioc;
   std::jthread ioc_thread;
-  tmc::detail::ex_any type_erased_this;
+  tmc::ex_any type_erased_this;
   bool is_initialized;
 
   /// Hook will be invoked at the startup of each thread owned by this executor,
@@ -110,7 +110,7 @@ public:
     init(ThreadCount);
   }
   inline ~ex_asio() { teardown(); }
-  inline tmc::detail::ex_any* type_erased() { return &type_erased_this; }
+  inline tmc::ex_any* type_erased() { return &type_erased_this; }
   inline void init_thread_locals() {
     tmc::detail::this_thread::executor = &type_erased_this;
     // tmc::detail::this_thread::this_task = {.prio = 0, .yield_priority =
@@ -186,7 +186,7 @@ template <> struct executor_traits<tmc::ex_asio> {
     ex.post_bulk(std::forward<It>(Items), Count, Priority, ThreadHint);
   }
 
-  static inline tmc::detail::ex_any* type_erased(tmc::ex_asio& ex) {
+  static inline tmc::ex_any* type_erased(tmc::ex_asio& ex) {
     return ex.type_erased();
   }
 

--- a/include/tmc/asio/ex_asio.hpp
+++ b/include/tmc/asio/ex_asio.hpp
@@ -56,6 +56,16 @@ public:
     return *this;
   }
 
+private:
+  inline void init_thread_locals() {
+    tmc::detail::this_thread::executor = &type_erased_this;
+  }
+
+  inline void clear_thread_locals() {
+    tmc::detail::this_thread::executor = nullptr;
+  }
+
+public:
   inline void init([[maybe_unused]] int ThreadCount = 1) {
     if (is_initialized) {
       return;
@@ -110,17 +120,13 @@ public:
     init(ThreadCount);
   }
   inline ~ex_asio() { teardown(); }
-  inline tmc::ex_any* type_erased() { return &type_erased_this; }
-  inline void init_thread_locals() {
-    tmc::detail::this_thread::executor = &type_erased_this;
-    // tmc::detail::this_thread::this_task = {.prio = 0, .yield_priority =
-    // &yield_priority[slot]};
-  }
 
-  inline void clear_thread_locals() {
-    tmc::detail::this_thread::executor = nullptr;
-    // tmc::detail::this_thread::this_task = {};
-  }
+  /// Returns a pointer to the type erased `ex_any` version of this executor.
+  /// This object shares a lifetime with this executor, and can be used for
+  /// pointer-based equality comparison against the thread-local
+  /// `tmc::current_executor()`.
+  inline tmc::ex_any* type_erased() { return &type_erased_this; }
+
   inline void graceful_stop() { ioc.stop(); }
 
   inline void post(

--- a/include/tmc/asio/ex_asio.hpp
+++ b/include/tmc/asio/ex_asio.hpp
@@ -30,7 +30,7 @@ public:
 #endif
   ioc_t ioc;
   std::jthread ioc_thread;
-  tmc::detail::type_erased_executor type_erased_this;
+  tmc::detail::ex_any type_erased_this;
   bool is_initialized;
 
   /// Hook will be invoked at the startup of each thread owned by this executor,
@@ -110,9 +110,7 @@ public:
     init(ThreadCount);
   }
   inline ~ex_asio() { teardown(); }
-  inline tmc::detail::type_erased_executor* type_erased() {
-    return &type_erased_this;
-  }
+  inline tmc::detail::ex_any* type_erased() { return &type_erased_this; }
   inline void init_thread_locals() {
     tmc::detail::this_thread::executor = &type_erased_this;
     // tmc::detail::this_thread::this_task = {.prio = 0, .yield_priority =
@@ -188,8 +186,7 @@ template <> struct executor_traits<tmc::ex_asio> {
     ex.post_bulk(std::forward<It>(Items), Count, Priority, ThreadHint);
   }
 
-  static inline tmc::detail::type_erased_executor* type_erased(tmc::ex_asio& ex
-  ) {
+  static inline tmc::detail::ex_any* type_erased(tmc::ex_asio& ex) {
     return ex.type_erased();
   }
 


### PR DESCRIPTION
This type may be useful to end users, so it's helpful to expose in the primary namespace. The new name is simple and to the point - "any" is a common term for a type erased object these days. I deliberately avoided calling it `any_executor` because there is already a type `asio::any_executor` and I want to avoid confusion with that. This name also follows the naming convention for the other executor types.