### PR TITLE
remove ThreadCount parameter from ex_asio

### DIFF
--- a/include/tmc/asio/ex_asio.hpp
+++ b/include/tmc/asio/ex_asio.hpp
@@ -70,7 +70,7 @@ private:
   }
 
 public:
-  inline void init([[maybe_unused]] int ThreadCount = 1) {
+  inline void init() {
     if (is_initialized) {
       return;
     }
@@ -119,10 +119,6 @@ public:
   }
 
   inline ex_asio() : ioc(1), type_erased_this(this), is_initialized(false) {}
-  inline ex_asio(int ThreadCount)
-      : ioc(ThreadCount), type_erased_this(this), is_initialized(false) {
-    init(ThreadCount);
-  }
   inline ~ex_asio() { teardown(); }
 
   /// Returns a pointer to the type erased `ex_any` version of this executor.


### PR DESCRIPTION
This parameter could only be set at constructor time because io_context requires the concurrency_hint as a constructor parameter. Currently it is unused as there is only 1 ex_asio thread.

It may come back at a later date but would require one of the following changes:
- using uninitialized storage to construct the io_context in at init() time
- using multiple parallel io_contexts in a share-nothing model