### PR TITLE
remove unnecessary overloads of run_on / resume_on

### DIFF
--- a/include/tmc/asio/aw_asio.hpp
+++ b/include/tmc/asio/aw_asio.hpp
@@ -235,11 +235,6 @@ struct async_result<tmc::aw_asio_t, void(ResultArgs...)> {
 
   public:
     /// The wrapped task will run on the provided executor.
-    [[nodiscard]] inline aw_asio& resume_on(tmc::ex_any* Executor) & {
-      this->customizer.continuation_executor = Executor;
-      return *this;
-    }
-    /// The wrapped task will run on the provided executor.
     template <typename Exec>
     [[nodiscard]] aw_asio& resume_on(Exec& Executor) & {
       this->customizer.continuation_executor =
@@ -254,11 +249,6 @@ struct async_result<tmc::aw_asio_t, void(ResultArgs...)> {
       return *this;
     }
 
-    /// The wrapped task will run on the provided executor.
-    [[nodiscard]] inline aw_asio&& resume_on(tmc::ex_any* Executor) && {
-      this->customizer.continuation_executor = Executor;
-      return std::move(*this);
-    }
     /// The wrapped task will run on the provided executor.
     template <typename Exec>
     [[nodiscard]] aw_asio&& resume_on(Exec& Executor) && {


### PR DESCRIPTION
Now that https://github.com/tzcnt/TooManyCooks/pull/115 implements executor_traits for `ex_any`, it doesn't need a special overload.