### PR TITLE
remove TMC_FORCE_INLINE from await_suspend functions

### DIFF
--- a/include/tmc/asio/aw_asio.hpp
+++ b/include/tmc/asio/aw_asio.hpp
@@ -128,8 +128,7 @@ template <typename Awaitable> struct aw_asio_impl {
 
   bool await_ready() { return false; }
 
-  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
-  ) noexcept {
+  inline void await_suspend(std::coroutine_handle<> Outer) noexcept {
     handle.customizer.continuation = Outer.address();
     handle.customizer.result_ptr = &result;
     handle.async_initiate();


### PR DESCRIPTION
On versions of Clang prior to 19 (when Clang MR 79712 was merged), await_suspend functions were decorated with noinline as a workaround for a codegen issue that would incorrectly store scratch space in the coroutine frame. Lately I've been experiencing some strange failures that show up as race conditions (some detected by TSan, some not) that I've been able to nail down using Clang 18 on one of my older machines. This is due to TMC_FORCE_INLINE overriding this internal compiler workaround.

By removing the forceinline attribute, the compiler will now be allowed to apply the correct mitigation on older compiler versions. On newer compiler versions, the inlining should be applied appropriately anyway - performance seems to be unchanged.